### PR TITLE
Don't break on image filenames with spaces in them

### DIFF
--- a/eval.lua
+++ b/eval.lua
@@ -133,7 +133,7 @@ local function eval_split(split, evalopt)
       table.insert(predictions, entry)
       if opt.dump_images == 1 then
         -- dump the raw image to vis/ folder
-        local cmd = 'cp ' .. path.join(opt.image_root, data.infos[k].file_path) .. ' vis/imgs/img' .. #predictions .. '.jpg' -- bit gross
+        local cmd = 'cp "' .. path.join(opt.image_root, data.infos[k].file_path) .. '" vis/imgs/img' .. #predictions .. '.jpg' -- bit gross
         print(cmd)
         os.execute(cmd) -- dont think there is cleaner way in Lua
       end


### PR DESCRIPTION
This fixes errors like the one below:

```
cp ./input/2012-02-11 12.02.42.jpg vis/imgs/img57.jpg
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-apvX] source_file target_file
       cp [-R [-H | -L | -P]] [-fi | -n] [-apvX] source_file ... target_directory
image 57: a laptop computer sitting on top of a wooden desk
```

The `cp` command executed will now be:

    cp "./input/2012-02-11 12.02.42.jpg" vis/imgs/img57.jpg