### PR TITLE
added dump_path option

### DIFF
--- a/eval.lua
+++ b/eval.lua
@@ -27,6 +27,7 @@ cmd:option('-num_images', 100, 'how many images to use when periodically evaluat
 cmd:option('-language_eval', 0, 'Evaluate language as well (1 = yes, 0 = no)? BLEU/CIDEr/METEOR/ROUGE_L? requires coco-caption code from Github.')
 cmd:option('-dump_images', 1, 'Dump images into vis/imgs folder for vis? (1=yes,0=no)')
 cmd:option('-dump_json', 1, 'Dump json with predictions into vis folder? (1=yes,0=no)')
+cmd:option('-dump_path', 0, 'Write image paths along with predictions into vis json? (1=yes,0=no)')
 -- Sampling options
 cmd:option('-sample_max', 1, '1 = sample argmax words. 0 = sample from distributions.')
 cmd:option('-beam_size', 2, 'used when sample_max = 1, indicates number of beams in beam search. Usually 2 or 3 works well. More is not better. Set this to 1 for faster runtime but a bit worse performance.')
@@ -135,6 +136,9 @@ local function eval_split(split, evalopt)
     local sents = net_utils.decode_sequence(vocab, seq)
     for k=1,#sents do
       local entry = {image_id = data.infos[k].id, caption = sents[k]}
+      if opt.dump_path == 1 then
+        entry.file_name = data.infos[k].file_path
+      end
       table.insert(predictions, entry)
       if opt.dump_images == 1 then
         -- dump the raw image to vis/ folder


### PR DESCRIPTION
The dump_path flag makes the script write the image path along with the caption in the resulting JSON file.

It should make easier to call the script and map the captions back to the images without risking to shift the ids when files are added or removed.