### PR TITLE
fixed README to reflect correct port for SimpleHTTPServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $ cd vis
 $ python -m SimpleHTTPServer
 ```
 
-Now visit `localhost:4000` in your browser and you should see your predicted captions.
+Now visit `localhost:8000` in your browser and you should see your predicted captions.
 
 You can see an [example visualization demo page here](http://cs.stanford.edu/people/karpathy/neuraltalk2/demo.html).
 


### PR DESCRIPTION
The README says localhost:4000 but it's being served at localhost:8000. Fixed that.
